### PR TITLE
Improve the handling of subscribe links

### DIFF
--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -20,6 +20,7 @@
         "redis": "^4.6.7"
       },
       "devDependencies": {
+        "@types/cookie-parser": "^1.4.4",
         "@types/express": "^4.17.17",
         "@types/node": "^18.7.1",
         "@typescript-eslint/eslint-plugin": "^6.1.0",
@@ -273,6 +274,15 @@
       "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha512-Var+aj5I6ZgIqsQ05N2V8q5OBrFfZXtIGWWDSrEYLIbMw758obagSwdGcLCjwh1Ga7M7+wj0SDIAaAC/WT7aaA==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cookie-session": {
@@ -3084,6 +3094,15 @@
       "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/cookie-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha512-Var+aj5I6ZgIqsQ05N2V8q5OBrFfZXtIGWWDSrEYLIbMw758obagSwdGcLCjwh1Ga7M7+wj0SDIAaAC/WT7aaA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
       }
     },
     "@types/cookie-session": {

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -27,6 +27,7 @@
     "redis": "^4.6.7"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.4",
     "@types/express": "^4.17.17",
     "@types/node": "^18.7.1",
     "@typescript-eslint/eslint-plugin": "^6.1.0",

--- a/back-end/src/routes.ts
+++ b/back-end/src/routes.ts
@@ -8,6 +8,7 @@ import {ClientData, getClientData, setClientData} from './db.js'
 import {sendSecretToClient} from './apns.js'
 import {createAblyPublishTokenRequest, createAblySubscribeTokenRequest, validateClientJwt} from './auth.js'
 import {randomUUID} from 'crypto'
+import {subscribe_response} from './templates.js';
 
 export async function apnsToken(req: express.Request, res: express.Response)  {
     const body: { [p: string]: string } = req.body
@@ -170,8 +171,8 @@ export async function subscribeToPublisher(req: express.Request, res: express.Re
     setCookie('publisherName', publisherName)
     setCookie('clientId', clientId)
     setCookie('clientName', req.cookies?.clientName || '')
-    res.setHeader('Location', `/listen/index.html`)
-    res.status(303).send()
+    const body = subscribe_response(publisherName)
+    res.status(200).send(body)
 }
 
 export async function subscribeTokenRequest(req: express.Request, res: express.Response) {

--- a/back-end/src/templates.ts
+++ b/back-end/src/templates.ts
@@ -7,11 +7,11 @@ export function subscribe_response(publisher_name: string) {
             <html lang="en">
             <head>
                 <meta charset="UTF-8">
-                <title>Listening to ${publisher_name}</title>
+                <title>Listen to ${publisher_name}</title>
                 <meta http-equiv="refresh" content="2; url=/listen/index.html">
             </head>
             <body>
-                <h1>Listening to ${publisher_name}</h1>
+                <h1>Listen to ${publisher_name}</h1>
                 <p>The whisper server is preparing your connection.  Please wait...</p>
             </body>
             </html>`

--- a/back-end/src/templates.ts
+++ b/back-end/src/templates.ts
@@ -1,0 +1,18 @@
+// Copyright 2023 Daniel C. Brotsky. All rights reserved.
+// Licensed under the GNU Affero General Public License v3.
+// See the LICENSE file for details.
+
+export function subscribe_response(publisher_name: string) {
+    return `<!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <title>Listening to ${publisher_name}</title>
+                <meta http-equiv="refresh" content="2; url=/listen/index.html">
+            </head>
+            <body>
+                <h1>Listening to ${publisher_name}</h1>
+                <p>The whisper server is preparing your connection.  Please wait...</p>
+            </body>
+            </html>`
+}


### PR DESCRIPTION
Because Apple fetches shared links in order to preview them, having the subscribe link redirect to the listen page caused the Apple shares to contain a link to the listen page, which didn't then have correct cookies and would fail.

With this PR, the subscribe link return an HTML page with the title "Listen to <whisperer name>" then then does an "HTML redirect" to the listen page (which will have the right cookies).  This causes Apple to send the subscribe link with an appropriate preview in the share.

This new behavior has been tested in browsers as well as the app.  Fixes clickonetwo/whisper#12.